### PR TITLE
Test upload-notebooks action

### DIFF
--- a/.github/workflows/upload-notebooks.yml
+++ b/.github/workflows/upload-notebooks.yml
@@ -1,0 +1,45 @@
+name: Test action upload-notebooks
+on:
+  push:
+    paths:
+      - '.github/workflows/upload-notebooks.yml'
+      - 'upload-notebooks/**'
+  pull_request:
+    paths:
+      - '.github/workflows/upload-notebooks.yml'
+      - 'upload-notebooks/**'
+  workflow_dispatch:
+jobs:
+  upload-notebooks-script:
+    runs-on: ${{ matrix.os }}
+    name: Test upload-notebooks.py (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Install tiledb-cloud
+      run: pip3 install tiledb "tiledb-cloud>=0.10.1"
+    - name: Test script
+      env:
+        TILEDB_CLOUD_TOKEN: ${{ secrets.TILEDB_CLOUD_TOKEN }}
+      run: cd upload-notebooks && bash test-upload-notebooks.sh
+  upload-notebooks-action:
+    runs-on: ${{ matrix.os }}
+    name: Test upload-notebooks action (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Upload notebooks
+      uses: ./upload-notebooks
+      with:
+        notebooks_local: ./upload-notebooks/notebook-example.ipynb
+        notebooks_remote: tiledb://TileDBCITesting/s3://tiledb-test/tiledb-cloud-upload-ci-testing/notebook-example
+        TILEDB_CLOUD_TOKEN: ${{ secrets.TILEDB_CLOUD_TOKEN }}
+        TILEDB_CLOUD_STORAGE_CREDENTIAL_NAME: IsaiahCloudKey

--- a/upload-notebooks/action.yml
+++ b/upload-notebooks/action.yml
@@ -26,15 +26,15 @@ runs:
   steps:
     - name: Install tiledb-cloud package in virtual env
       run: |
-        python -m venv "$RUNNER_TEMP/pyenv"
-        "$RUNNER_TEMP/pyenv/bin/pip" install "tiledb-cloud>=0.10.1"
+        python3 -m venv "$RUNNER_TEMP/pyenv"
+        "$RUNNER_TEMP/pyenv/bin/pip" install tiledb "tiledb-cloud>=0.10.1"
         "$RUNNER_TEMP/pyenv/bin/pip" list
       shell: bash
     - name: Upload notebooks
       env:
         TILEDB_CLOUD_TOKEN: ${{ inputs.TILEDB_CLOUD_TOKEN }}
       run: |
-        "$RUNNER_TEMP/pyenv/bin/python" \
+        "$RUNNER_TEMP/pyenv/bin/python3" \
           "${{ github.action_path }}/upload-notebooks.py" \
           --notebooks-local ${{ inputs.notebooks_local }} \
           --notebooks-remote ${{ inputs.notebooks_remote }} \

--- a/upload-notebooks/test-upload-notebooks.sh
+++ b/upload-notebooks/test-upload-notebooks.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 set -u
 
+set -e
+
 echo -e "\n===\nTest: Upload minimal example notebook\n==="
 NOTEBOOK_EXAMPLE="notebook-example-$RANDOM.ipynb"
 cp notebook-example.ipynb $NOTEBOOK_EXAMPLE
-python upload-notebooks.py \
+python3 upload-notebooks.py \
   --notebooks-local $NOTEBOOK_EXAMPLE \
-  --notebooks-remote tiledb://jdblischak/s3://tiledb-cloud-jdblischak/notebooks/${NOTEBOOK_EXAMPLE%.ipynb} \
-  --tiledb-cloud-storage-credential-name personal-aws \
+  --notebooks-remote tiledb://TileDBCITesting/s3://tiledb-test/tiledb-cloud-upload-ci-testing/${NOTEBOOK_EXAMPLE%.ipynb} \
+  --tiledb-cloud-storage-credential-name IsaiahCloudKey \
   --delete-remote-notebooks
 rm $NOTEBOOK_EXAMPLE
 
+# The below examples purposefully trigger errors
+set +e
+
 echo -e "\n===\nTest: Fail for missing remote URI \n==="
-python upload-notebooks.py \
+python3 upload-notebooks.py \
   --notebooks-local \
     notebook-1.ipynb \
     notebook-2.ipynb \
@@ -20,13 +25,13 @@ python upload-notebooks.py \
     tiledb://namespace/s3://notebook-1
 
 echo -e "\n===\nTest: Fail for missing notebook\n==="
-python upload-notebooks.py \
+python3 upload-notebooks.py \
   --notebooks-local missing.ipynb \
   --notebooks-remote tiledb://namespace/s3://missing
 
 echo -e "\n===\nTest: Fail for wrong extension\n==="
 touch wrong-extension.txt
-python upload-notebooks.py \
+python3 upload-notebooks.py \
   --notebooks-local wrong-extension.txt \
   --notebooks-remote tiledb://namespace/s3://wrong-extension
 rm wrong-extension.txt

--- a/upload-notebooks/upload-notebooks.py
+++ b/upload-notebooks/upload-notebooks.py
@@ -53,7 +53,7 @@ parser.add_argument(
 parser.add_argument(
     "--delete-remote-notebooks",
     action="store_true",
-    help="(Testing purposes only) Delete test notebook(s) from TileDB Cloud after successful upload",
+    help="(Testing purposes only) Delete test notebook(s) from TileDB Cloud (and AWS) after successful upload",
 )
 args = parser.parse_args()
 
@@ -131,5 +131,6 @@ for i in range(len(notebooks_local)):
     sys.stderr.write("Info: Uploaded to %s\n" % (uploaded))
 
     if delete_remote_notebooks:
-        tiledb.cloud.deregister_array(uri)
-        sys.stderr.write("Info: Deregistered remote notebook %s\n" % (uri))
+        with tiledb.scope_ctx(tiledb.cloud.Ctx()):
+            tiledb.Array.delete_array(uri)
+        sys.stderr.write("Info: Deleted remote notebook %s\n" % (uri))


### PR DESCRIPTION
This PR adds the following:

* Option to delete test notebook from S3 (as opposed to only deregistering from TileDB Cloud)
* Test upload-notebooks action in GitHub Actions pipeline using test account TileDBCITesting

To do:

- [x] Create TileDB Cloud API token with scope `array:admin`, and then add as repository secret named `TILEDB_CLOUD_TOKEN `