### PR TITLE
Create open-issue action

### DIFF
--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -26,7 +26,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         TZ: "America/New_York"
         OPEN_ISSUE_ACTION_NAME: Nightly build
-        OPEN_ISSUE_ACTION_LABEL: wontfix,bug
+        OPEN_ISSUE_ACTION_LABEL: wontfix,help wanted
         OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
       shell: bash
@@ -47,7 +47,7 @@ jobs:
       uses: ./open-issue
       with:
         name: Nightly build
-        label: wontfix,bug
+        label: wontfix,help wanted
         assignee: jdblischak
   close-issue:
     permissions:

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -23,8 +23,8 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         TZ: "America/New_York"
         OPEN_ISSUE_ACTION_NAME: Nightly build
-        OPEN_ISSUE_ACTION_LABEL:  wontfix
-        OPEN_ISSUE_ACTION_ASSIGNEE:  jdblischak
+        OPEN_ISSUE_ACTION_LABEL: wontfix
+        OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
       shell: bash
   open-issue-action:
@@ -43,7 +43,7 @@ jobs:
       uses: ./open-issue
       with:
         name: Nightly build
-        label: bug
+        label: wontfix
         assignee: jdblischak
   close-issue:
     permissions:
@@ -56,21 +56,10 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-    - name: Close Issue from open-issue-script
+    - name: Close test Issue
       run: |
         existing=$(gh issue list \
           --label wontfix \
-          --limit 1 \
-          --jq '.[].number' \
-          --json "number" \
-          --state "open")
-
-        gh issue close "$existing"
-      shell: bash
-    - name: Close Issue from open-issue-action
-      run: |
-        existing=$(gh issue list \
-          --label bug \
           --limit 1 \
           --jq '.[].number' \
           --json "number" \

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -9,6 +9,7 @@ on:
       - 'open-issue/**'
   workflow_dispatch:
 jobs:
+  # Test the script directly
   open-issue-script:
     permissions:
       issues: write
@@ -26,10 +27,11 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         TZ: "America/New_York"
         OPEN_ISSUE_ACTION_NAME: Nightly build
-        OPEN_ISSUE_ACTION_LABEL: wontfix,help wanted
+        OPEN_ISSUE_ACTION_LABEL: wontfix
         OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
       shell: bash
+  # Test the action
   open-issue-action:
     permissions:
       issues: write
@@ -47,8 +49,9 @@ jobs:
       uses: ./open-issue
       with:
         name: Nightly build
-        label: wontfix,help wanted
+        label: wontfix
         assignee: jdblischak
+  # cleanup
   close-issue:
     permissions:
       issues: write

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -1,0 +1,84 @@
+name: Test action open-issue
+on:
+  push:
+    paths:
+      - '.github/workflows/open-issue.yml'
+      - 'open-issue/**'
+  pull_request:
+    paths:
+      - '.github/workflows/open-issue.yml'
+      - 'open-issue/**'
+  workflow_dispatch:
+jobs:
+  open-issue-script:
+    permissions:
+      issues: write
+    runs-on: ${{ matrix.os }}
+    name: Test open-issue.sh (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Test script
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TZ: "America/New_York"
+        OPEN_ISSUE_ACTION_NAME: Nightly build
+        OPEN_ISSUE_ACTION_LABEL:  wontfix
+        OPEN_ISSUE_ACTION_ASSIGNEE:  jdblischak
+      run: cd open-issue && bash open-issue.sh
+      shell: bash
+  open-issue-action:
+    permissions:
+      issues: write
+    runs-on: ${{ matrix.os }}
+    name: Test open-issue action (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Test action
+      uses: ./open-issue
+      with:
+        name: Nightly build
+        label: bug
+        assignee: jdblischak
+  close-issue:
+    permissions:
+      issues: write
+    needs: [open-issue-script, open-issue-action]
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Close Issue from open-issue-script
+      run: |
+        existing=$(gh issue list \
+          --label wontfix \
+          --limit 1 \
+          --jq '.[].number' \
+          --json "number" \
+          --state "open")
+
+        gh issue close "$existing"
+      shell: bash
+    - name: Close Issue from open-issue-action
+      run: |
+        existing=$(gh issue list \
+          --label bug \
+          --limit 1 \
+          --jq '.[].number' \
+          --json "number" \
+          --state "open")
+
+        gh issue close "$existing"
+      shell: bash

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -32,9 +32,6 @@ jobs:
         OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
       shell: bash
-    - name: Report Issue number
-      run: echo ${{ steps.open-issue.outputs.issue-number }}
-      shell: bash
   # Test the action
   open-issue-action:
     permissions:

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -4,10 +4,6 @@ on:
     paths:
       - '.github/workflows/open-issue.yml'
       - 'open-issue/**'
-  pull_request:
-    paths:
-      - '.github/workflows/open-issue.yml'
-      - 'open-issue/**'
   workflow_dispatch:
 jobs:
   open-issue-script:

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
     - name: Test script
+      id: open-issue
       env:
         GH_TOKEN: ${{ github.token }}
         TZ: "America/New_York"
@@ -30,6 +31,9 @@ jobs:
         OPEN_ISSUE_ACTION_LABEL: wontfix
         OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
+      shell: bash
+    - name: Report Issue number
+      run: echo ${{ steps.open-issue.outputs.issue-number }}
       shell: bash
   # Test the action
   open-issue-action:
@@ -51,8 +55,6 @@ jobs:
         name: Nightly build
         label: wontfix
         assignee: jdblischak
-    - name: Report Issue number
-      run: echo ${{ steps.open-issue.outputs.issue-number }}
   # cleanup
   close-issue:
     permissions:

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -23,8 +23,8 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         TZ: "America/New_York"
         OPEN_ISSUE_ACTION_NAME: Nightly build
-        OPEN_ISSUE_ACTION_LABEL: wontfix
-        #OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
+        OPEN_ISSUE_ACTION_LABEL: wontfix,bug
+        OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
       shell: bash
   open-issue-action:
@@ -44,8 +44,8 @@ jobs:
       uses: ./open-issue
       with:
         name: Nightly build
-        label: wontfix
-        #assignee: jdblischak
+        label: wontfix,bug
+        assignee: jdblischak
   close-issue:
     permissions:
       issues: write

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -1,6 +1,9 @@
 name: Test action open-issue
 on:
   push:
+    # Only create test Issue on branches, not post-merge
+    branches-ignore:
+      - main
     paths:
       - '.github/workflows/open-issue.yml'
       - 'open-issue/**'

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -24,7 +24,7 @@ jobs:
         TZ: "America/New_York"
         OPEN_ISSUE_ACTION_NAME: Nightly build
         OPEN_ISSUE_ACTION_LABEL: wontfix
-        OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
+        #OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
       shell: bash
   open-issue-action:
@@ -44,7 +44,7 @@ jobs:
       with:
         name: Nightly build
         label: wontfix
-        assignee: jdblischak
+        #assignee: jdblischak
   close-issue:
     permissions:
       issues: write

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -51,6 +51,8 @@ jobs:
         name: Nightly build
         label: wontfix
         assignee: jdblischak
+    - name: Report Issue number
+      run: echo ${{ steps.open-issue.outputs.issue-number }}
   # cleanup
   close-issue:
     permissions:

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -30,6 +30,7 @@ jobs:
   open-issue-action:
     permissions:
       issues: write
+    needs: [open-issue-script]
     runs-on: ${{ matrix.os }}
     name: Test open-issue action (${{ matrix.os }})
     strategy:

--- a/.github/workflows/open-issue.yml
+++ b/.github/workflows/open-issue.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         TZ: "America/New_York"
-        OPEN_ISSUE_ACTION_NAME: Nightly build
+        OPEN_ISSUE_ACTION_NAME: nightly build
         OPEN_ISSUE_ACTION_LABEL: wontfix
         OPEN_ISSUE_ACTION_ASSIGNEE: jdblischak
       run: cd open-issue && bash open-issue.sh
@@ -49,7 +49,7 @@ jobs:
     - name: Test action
       uses: ./open-issue
       with:
-        name: Nightly build
+        name: nightly build
         label: wontfix
         assignee: jdblischak
   # cleanup

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # TileDB GitHub Actions
 
+* `open-issue` - Open a new Issue (or comment on an existing one)
 * `upload-notebooks` - Upload Jupyter notebooks to TileDB Cloud

--- a/open-issue/README.md
+++ b/open-issue/README.md
@@ -1,0 +1,34 @@
+# Open GitHub Issue
+
+Insert this action into your GitHub Actions workflow to automatically open an
+Issue from a GitHub Actions job (or comment on an existing open Issue). This
+requires that the default GitHub token in the job has write permissions to
+Issues.
+
+Example:
+
+```yaml
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: build
+    if: ( failure() || cancelled() ) && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        uses: ./open-issue
+        with:
+          name: Nightly build
+          label: bug
+          assignee: username
+```
+
+Notes on the example:
+
+* Requests the GitHub token to have permission to write to Issues (the minimum
+  scope required for this action)
+* Can run on macOS, Ubuntu, and Windows runners
+* Assumes the job above is named "build"
+* Only opens the Issue if the job "build" fails or is cancelled
+* Only opens the Issue if the job was scheduled

--- a/open-issue/README.md
+++ b/open-issue/README.md
@@ -19,7 +19,7 @@ Example:
       - name: Open Issue
         uses: ./open-issue
         with:
-          name: Nightly build
+          name: nightly build
           label: bug
           assignee: username
 ```

--- a/open-issue/action.yml
+++ b/open-issue/action.yml
@@ -1,0 +1,31 @@
+name: Open Issue
+description: Open a new Issue (or comment on an existing one)
+inputs:
+  name:
+    description: >-
+      Name to identify the job. Will be used in the Issue title and message body.
+      For the best formatting, use capital case (eg "Nightly build")
+    required: true
+  label:
+    description: >-
+      Comma-separated list of labels to assign to the Issue (eg "nightly,bug").
+      The label must already exist for the repository
+    required: true
+  assignee:
+    description: >-
+      Comma-separated list of GitHub usernames to assign to the Issue (eg
+      "user1,user2"). The GitHub accounts must be collaborators on the
+      repository
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Open Issue
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TZ: "America/New_York"
+        OPEN_ISSUE_ACTION_NAME:  ${{ inputs.name }}
+        OPEN_ISSUE_ACTION_LABEL:  ${{ inputs.label }}
+        OPEN_ISSUE_ACTION_ASSIGNEE:  ${{ inputs.assignee }}
+      run: bash "${{ github.action_path }}/open-issue.sh"
+      shell: bash

--- a/open-issue/action.yml
+++ b/open-issue/action.yml
@@ -3,8 +3,8 @@ description: Open a new Issue (or comment on an existing one)
 inputs:
   name:
     description: >-
-      Name to identify the job. Will be used in the Issue title and message body.
-      For the best formatting, use capital case (eg "Nightly build")
+      Name to identify the job. Will be used in the Issue title and message
+      body. Can include spaces. The title begins "The <name> job failed on..."
     required: true
   label:
     description: >-

--- a/open-issue/action.yml
+++ b/open-issue/action.yml
@@ -17,10 +17,6 @@ inputs:
       "user1,user2"). The GitHub accounts must be collaborators on the
       repository
     required: false
-outputs:
-  issue-number:
-    description: "Random number"
-    value: ${{ steps.open-issue.outputs.issue-number }}
 runs:
   using: "composite"
   steps:

--- a/open-issue/action.yml
+++ b/open-issue/action.yml
@@ -17,10 +17,15 @@ inputs:
       "user1,user2"). The GitHub accounts must be collaborators on the
       repository
     required: false
+outputs:
+  issue-number:
+    description: "Random number"
+    value: ${{ steps.open-issue.outputs.issue-number }}
 runs:
   using: "composite"
   steps:
     - name: Open Issue
+      id: open-issue
       env:
         GH_TOKEN: ${{ github.token }}
         TZ: "America/New_York"

--- a/open-issue/open-issue.sh
+++ b/open-issue/open-issue.sh
@@ -42,13 +42,4 @@ else
     --body "$theMessage"
 fi
 
-# Save the Issue number as output
-issueNumber=$(gh issue list \
-  --label "$OPEN_ISSUE_ACTION_LABEL" \
-  --limit 1 \
-  --jq '.[].number' \
-  --json "number" \
-  --state "open")
-echo "issue-number=$IssueNumber" >> $GITHUB_OUTPUT
-
 echo "Success!"

--- a/open-issue/open-issue.sh
+++ b/open-issue/open-issue.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -ex
+
+# Open new Issue (or comment on existing)
+
+if [[ -z "$GH_TOKEN" ]]
+then
+  echo "The env var GH_TOKEN is missing"
+  echo "Please define it as a GitHub PAT with write permissions to Issues"
+  exit 1
+fi
+
+theDate="$(date '+%A (%Y-%m-%d)')"
+theMessage="$OPEN_ISSUE_ACTION_NAME failed on $theDate in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+
+existing=$(gh issue list \
+  --label "$OPEN_ISSUE_ACTION_LABEL" \
+  --limit 1 \
+  --jq '.[].number' \
+  --json "number" \
+  --state "open")
+
+if [[ -z "$existing" ]]
+then
+  # open new issue
+  gh issue create \
+    --assignee $OPEN_ISSUE_ACTION_ASSIGNEE \
+    --body "$theMessage" \
+    --label "$OPEN_ISSUE_ACTION_LABEL" \
+    --title "$OPEN_ISSUE_ACTION_NAME failed on $theDate"
+else
+  # comment on existing issue
+  gh issue comment "$existing" \
+    --body "$theMessage"
+fi
+
+echo "Success!"

--- a/open-issue/open-issue.sh
+++ b/open-issue/open-issue.sh
@@ -11,7 +11,7 @@ then
 fi
 
 theDate="$(date '+%A (%Y-%m-%d)')"
-theMessage="$OPEN_ISSUE_ACTION_NAME failed on $theDate in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+theMessage="The $OPEN_ISSUE_ACTION_NAME job failed on $theDate in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
 
 # --assignee flag is optional
 if [[ -n "$OPEN_ISSUE_ACTION_ASSIGNEE" ]]
@@ -35,7 +35,7 @@ then
     $flagAssignee \
     --body "$theMessage" \
     --label "$OPEN_ISSUE_ACTION_LABEL" \
-    --title "$OPEN_ISSUE_ACTION_NAME failed on $theDate"
+    --title "The $OPEN_ISSUE_ACTION_NAME job failed on $theDate"
 else
   # comment on existing issue
   gh issue comment "$existing" \

--- a/open-issue/open-issue.sh
+++ b/open-issue/open-issue.sh
@@ -13,6 +13,14 @@ fi
 theDate="$(date '+%A (%Y-%m-%d)')"
 theMessage="$OPEN_ISSUE_ACTION_NAME failed on $theDate in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
 
+# --assignee flag is optional
+if [[ -n "$OPEN_ISSUE_ACTION_ASSIGNEE" ]]
+then
+  flagAssignee="--assignee $OPEN_ISSUE_ACTION_ASSIGNEE"
+else
+  flagAssignee=""
+fi
+
 existing=$(gh issue list \
   --label "$OPEN_ISSUE_ACTION_LABEL" \
   --limit 1 \
@@ -24,7 +32,7 @@ if [[ -z "$existing" ]]
 then
   # open new issue
   gh issue create \
-    --assignee $OPEN_ISSUE_ACTION_ASSIGNEE \
+    $flagAssignee \
     --body "$theMessage" \
     --label "$OPEN_ISSUE_ACTION_LABEL" \
     --title "$OPEN_ISSUE_ACTION_NAME failed on $theDate"

--- a/open-issue/open-issue.sh
+++ b/open-issue/open-issue.sh
@@ -42,4 +42,13 @@ else
     --body "$theMessage"
 fi
 
+# Save the Issue number as output
+issueNumber=$(gh issue list \
+  --label "$OPEN_ISSUE_ACTION_LABEL" \
+  --limit 1 \
+  --jq '.[].number' \
+  --json "number" \
+  --state "open")
+echo "issue-number=$IssueNumber" >> $GITHUB_OUTPUT
+
 echo "Success!"


### PR DESCRIPTION
This is the initial draft for the reusable action to open Issues automatically from a GitHub Actions job. Feedback welcome.

Known areas for improvement:

* [x] Support the use case where no assignee is provided
* [x] Test multiple labels (and labels with spaces)
* [ ] ~~Save the GitHub Issue number as an [output](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions) for potential use in downstream steps~~
  * This ended up being more complicated than I had anticipated. My main motivation for this was my testing pipeline, so let's wait until someone requests this feature before I attempt to implement it

xref: https://github.com/TileDB-Inc/TileDB-Py/pull/1813