### PR TITLE
Some updates for open-issue 

### DIFF
--- a/open-issue/README.md
+++ b/open-issue/README.md
@@ -5,6 +5,23 @@ Issue from a GitHub Actions job (or comment on an existing open Issue). This
 requires that the default GitHub token in the job has write permissions to
 Issues.
 
+Usage notes (see `action.yml` for more details):
+
+* The required argument `name` is used in the Issue title and body
+* The required argument `label` is used to identify an existing open Issue to
+  comment on. Thus the label (or combination of labels) must be specific to this
+  auto-opened Issue. If you were to only use a generic label like `bug`, then
+  the action would comment on the most recent Issue with that label. To use a
+  new unique label, you must manually create it on the repository first. Trying
+  to use a non-existing label with this action will result in an error
+* The argument `assignee` is optional. If you list any users that do not have
+  write-access to the repository, then they will simply be ignored
+* You don't need to explicitly pass the GitHub token to the action. This is
+  already automatically done by the action. The only requirement is that you set
+  `issues: write` in the `permissions`. While you could set this permission for
+  the entire workflow, it's best practice to limit the escalated authentication
+  for only the job(s) that require it
+
 Example:
 
 ```yaml
@@ -20,7 +37,7 @@ Example:
         uses: ./open-issue
         with:
           name: nightly build
-          label: bug
+          label: bug,nightly-failure
           assignee: username
 ```
 
@@ -29,6 +46,9 @@ Notes on the example:
 * Requests the GitHub token to have permission to write to Issues (the minimum
   scope required for this action)
 * Can run on macOS, Ubuntu, and Windows runners
-* Assumes the job above is named "build"
+* Assumes the job above that might fail is named "build"
 * Only opens the Issue if the job "build" fails or is cancelled
 * Only opens the Issue if the job was scheduled
+* If there is an existing open Issue with the labels `bug` and
+  `nightly-failure`, the action will comment on this Issue instead of opening a
+  new one

--- a/open-issue/open-issue.sh
+++ b/open-issue/open-issue.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 # Open new Issue (or comment on existing)
 
@@ -12,6 +12,7 @@ fi
 
 theDate="$(date '+%A (%Y-%m-%d)')"
 theMessage="The $OPEN_ISSUE_ACTION_NAME job failed on $theDate in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+echo "$theMessage"
 
 # --assignee flag is optional
 if [[ -n "$OPEN_ISSUE_ACTION_ASSIGNEE" ]]
@@ -30,14 +31,14 @@ existing=$(gh issue list \
 
 if [[ -z "$existing" ]]
 then
-  # open new issue
+  echo "Opening new issue"
   gh issue create \
     $flagAssignee \
     --body "$theMessage" \
     --label "$OPEN_ISSUE_ACTION_LABEL" \
     --title "The $OPEN_ISSUE_ACTION_NAME job failed on $theDate"
 else
-  # comment on existing issue
+  echo "Commenting on existing issue"
   gh issue comment "$existing" \
     --body "$theMessage"
 fi


### PR DESCRIPTION
Follow up to #4. While working on https://github.com/TileDB-Inc/TileDB-Py/pull/1821, I realized some ideas for improvement:

* Use `echo` instead of `-x`. Don't want any sensitive information to accidentally leak
* Make it clearer in the documentation that the feature to comment on an existing open Issue requires using a unique label, and that this label needs to be manually created